### PR TITLE
Add `Makefile`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,7 @@ jobs:
       - restore_all_dependency_cache
       - run:
           name: run pylint
-          command: |
-            source env/bin/activate
-            pylint src tests
+          command: make lint
       - run:
           name: run mypy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,7 @@ jobs:
           command: make lint
       - run:
           name: run mypy
-          command: |
-            source env/bin/activate
-            mypy . --strict
+          command: make typecheck
   unit-tests:
     # Runs the test framework
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,10 +241,7 @@ jobs:
             # Additional args for `sphinx-build`
             #   * -b:
             #     The type of documentation to create
-          command: |
-            source env/bin/activate
-            sphinx-apidoc -f -o docs/source src/python_package_template
-            sphinx-build -b html docs/source docs/build
+          command: make docs-build
       - run:
           name: compress artifacts
           # We compress the artifacts to improve speed and allow all docs to be

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,11 +118,7 @@ jobs:
           key: all-deps-{{ checksum "requirements-all.txt"}}
       - run:
           name: install dependencies
-          command: |
-            python3 -m venv env
-            source env/bin/activate
-            python3 -m pip install -r requirements.txt
-            python3 -m pip install -r requirements-dev.txt
+          command: make install
       - save_cache:
           key: all-deps-{{ checksum "requirements-all.txt"}}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,12 +173,7 @@ jobs:
           #     Requests XML output format
           # * -o:
           #     Specifies the path of the output coverage file
-          command: |
-            source env/bin/activate
-            mkdir reports/coverage --parents
-            python3 -m pytest
-            python3 -m pytest --cov=python_package_template --junitxml=reports/coverage/test_summary.xml -rxXs
-            coverage xml -o reports/coverage/test_coverage.xml
+          command: make test-coverage
       - store_test_results:
           # Store the auto-generated reports for further analysis (if required)
           # See: https://circleci.com/docs/2.0/collect-test-data/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,10 +211,7 @@ jobs:
       - restore_all_dependency_cache
       - run:
           name: build distribution archives
-          command: |
-            source env/bin/activate
-            python3 -m pip install wheel
-            python3 setup.py sdist bdist_wheel
+          command: make buid-dist
       - store_artifacts:
           # Store the build artifacts
           path: dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
           key: all-deps-{{ checksum "requirements-all.txt"}}
       - run:
           name: install dependencies
-          command: make install
+          command: make install-python-deps
       - save_cache:
           key: all-deps-{{ checksum "requirements-all.txt"}}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,28 +147,6 @@ jobs:
       - restore_all_dependency_cache
       - run:
           name: run tests
-          # Run the test suite
-          #
-          # Steps:
-          # - Stores junit-formatted XML in reports/coverage/test_summary.xml
-          # - Processes the test coverage and stores a coverage report in
-          #   reports/coverage/test_coverage.xml
-          #
-          # Additional args for `pytest`:
-          # * --cov=python_package_template:
-          #     Requests a coverage report of the module
-          # * --junitxml=reports/coverage/test_cov.xml
-          #     Store test coverage report in a junit-formatted XML file
-          # * tests:
-          #     The name of the folder containing the test_*.py files
-          # * -rxXs
-          #     Prints a short summary of the skipped & xfail tests
-          #
-          # Additional args for `coverage`:
-          # * xml:
-          #     Requests XML output format
-          # * -o:
-          #     Specifies the path of the output coverage file
           command: make test-coverage
       - store_test_results:
           # Store the auto-generated reports for further analysis (if required)
@@ -187,19 +165,9 @@ jobs:
       - restore_all_dependency_cache
       - run:
           name: run bandit
-          # Run `bandit` on the directory
-          #
-          # Additional args:
-          # * -r:
-          #   Recurse over the directory contents
-          # * -x:
-          #   Exclude the `./env` directory
-          # * -s:
-          #   Skip the B101 tests (assert_used)
           command: make security-application
       - run:
           name: run safety
-          # Run `safety` on the current environment
           command: make security-dependency
   build-dist:
     # Creates the source and built distribution archives
@@ -225,22 +193,6 @@ jobs:
       - restore_all_dependency_cache
       - run:
           name: build docs
-            # Automatically builds the documentation
-            #
-            # Steps:
-            #   - Build dynamic docmentation from the docstrings in the Python
-            #     files and modules found in `src/python_package_template`
-            #   - Build the static documentation files in `docs/source`
-            #
-            # Additional args for `sphinx-apidoc`:
-            #   * -f:
-            #     Force `apidoc` to overwrite files
-            #   * -o:
-            #     The target directory for the auto-generated docs
-            #
-            # Additional args for `sphinx-build`
-            #   * -b:
-            #     The type of documentation to create
           command: make build-docs
       - run:
           name: compress artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,15 +196,11 @@ jobs:
           #   Exclude the `./env` directory
           # * -s:
           #   Skip the B101 tests (assert_used)
-          command: |
-            source env/bin/activate
-            bandit -r -x ./env -s B101 .
+          command: make security-application
       - run:
           name: run safety
           # Run `safety` on the current environment
-          command: |
-            source env/bin/activate
-            pip freeze | safety check --stdin
+          command: make security-dependency
   build-dist:
     # Creates the source and built distribution archives
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
       - restore_all_dependency_cache
       - run:
           name: build distribution archives
-          command: make buid-dist
+          command: make build-dist
       - store_artifacts:
           # Store the build artifacts
           path: dist
@@ -241,7 +241,7 @@ jobs:
             # Additional args for `sphinx-build`
             #   * -b:
             #     The type of documentation to create
-          command: make docs-build
+          command: make build-docs
       - run:
           name: compress artifacts
           # We compress the artifacts to improve speed and allow all docs to be

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-coverage: activate-env ## Run the full test suite and generate coverage rep
 lint: ## Run linting tools on the application code
 	@$(PYTHON) -m pylint $(APPLICATION_DIR) $(TEST_DIR)
 
-typecheck: activate-env ## Run static type checking on the application code
+typecheck: ## Run static type checking on the application code
 	@$(PYTHON) -m mypy . --strict
 
 format: lint typecheck ## Run linting and type-checking

--- a/Makefile
+++ b/Makefile
@@ -82,14 +82,17 @@ typecheck: ## Run static type checking on the application code
 
 format: lint typecheck ## Run linting and type-checking
 
-pre-commit-install: activate-env ## Install pre-commit
+pre-commit-install: ## Install pre-commit
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
 	pre-commit install
 
-pre-commit: activate-env ## Run pre-commit on staged files
-	@pre-commit run
+pre-commit: ## Run pre-commit on staged files
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	pre-commit run
 
-pre-commit-all: activate-env ## Run pre-commit on all files
-	@pre-commit run --all-files
+pre-commit-all: ## Run pre-commit on all files
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	pre-commit run --all-files
 
 # TODO - Something like this would be better
 # FILES_TO_CLEAN = (test_summary.xml test_coverage.xml .coverage)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ test: activate-env ## Run the full test suite
 #  * --cov-report xml:test_coverage.xml
 #     Requests an XML-formatted coverage report named test_coverage.xml
 test-coverage: ## Run the full test suite and generate coverage reports
-	@mkdir reports/coverage --parents && \
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	mkdir reports/coverage --parents && \
 	$(PYTHON) -m pytest -rxXs \
 	--cov=$(APPLICATION_DIR) \
 	--junitxml=test_summary.xml \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 TASKS = \
 	help \
 	create-env \
-	active-env \
 	install-python-deps \
 	install \
 	test \
@@ -39,11 +38,9 @@ help:
 create-env: ## Creates the virtual environment directory
 	@python3 -m venv $(VIRTUAL_ENV_DIRECTORY)
 
-activate-env: ## Activates the virtual environment
-	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate
-
-install-python-deps: create-env activate-env ## Install the Python dependencies in the virtual environment
-	@python3 -m pip install -r requirements.txt -r requirements-dev.txt
+install-python-deps: create-env ## Creat the virtual environment and install the Python dependencies
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	python3 -m pip install -r requirements.txt -r requirements-dev.txt
 
 # TODO - This is crying out for Docker...
 install: install-python-deps pre-commit-install ## Install the code and pre-commit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,103 @@
+TASKS = \
+	help \
+	create-env \
+	active-env \
+	install-python-deps \
+	install \
+	test \
+	test-coverage \
+	lint \
+	typecheck \
+	format \
+	pre-commit-install \
+	pre-commit \
+	pre-commit-all \
+	clean \
+
+# PHONY targets do not depend on an external file
+.PHONY = $(TASKS)
+
+# .DEFAULT_GOAL is the target that is executed when 'make' is typed
+.DEFAULT_GOAL = help
+
+PYTHON = python3
+
+# Location of application and test code
+APPLICATION_DIR = src/python_package_template/
+TEST_DIR = tests/
+
+# Name of the virtual environment directory
+VIRTUAL_ENV_DIRECTORY = env
+
+# https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	sort | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+create-env: ## Creates the virtual environment directory
+	@$(PYTHON) -m venv $(VIRTUAL_ENV_DIRECTORY)
+
+activate-env: ## Activates the virtual environment
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate
+
+install-python-deps: create-env activate-env ## Install the Python dependencies in the virtual environment
+	@$(PYTHON) -m pip install -r requirements.txt -r requirements-dev.txt
+
+# TODO - This is crying out for Docker...
+install: install-python-deps pre-commit-install ## Install the code and pre-commit
+
+# Run the test suite with the following options:
+#  * -rxXs
+#     Provide a detailed summary report.
+#     https://docs.pytest.org/en/6.2.x/usage.html#detailed-summary-report
+test: activate-env ## Run the full test suite
+	@$(PYTHON) -m pytest -rxXs
+
+# Run the test suite with the following options:
+#  * -rxXs
+#     Provide a detailed summary report.
+#     https://docs.pytest.org/en/6.2.x/usage.html#detailed-summary-report
+#
+#  * --cov=$(APPLICATION_DIR)
+#     Request coverage of the code in the  application directory
+#
+#  * --junitxml=test_summary.xml
+#     Define the file name and format for the coverage report
+#
+#  * --cov-report xml:test_coverage.xml
+#     Requests an XML-formatted coverage report named test_coverage.xml
+test-coverage: ## Run the full test suite and generate coverage reports
+	@$(PYTHON) -m pytest -rxXs \
+	--cov=$(APPLICATION_DIR) \
+	--junitxml=test_summary.xml \
+	--cov-report xml:test_coverage.xml
+
+lint: ## Run linting tools on the application code
+	@$(PYTHON) -m pylint $(APPLICATION_DIR) $(TEST_DIR)
+
+typecheck: ## Run static type checking on the application code
+	@$(PYTHON) -m mypy . --strict
+
+format: lint typecheck ## Run linting and type-checking
+
+pre-commit-install: activate-env ## Install pre-commit
+	pre-commit install
+
+pre-commit: activate-env ## Run pre-commit on staged files
+	@pre-commit run
+
+pre-commit-all: activate-env ## Run pre-commit on all files
+	@pre-commit run --all-files
+
+# TODO - Something like this would be better
+# FILES_TO_CLEAN = (test_summary.xml test_coverage.xml .coverage)
+# for file in ${FILES_TO_CLEAN[@]}; do
+# 	if [[ -f file ]]; then rm file; fi
+# done
+clean: ## Remove any artifacts created by the make targets
+	@echo "Need to figure out how to get this working!"
+	# if [[ -f test_summary.xml ]]; then rm test_summary.xml; fi && \
+	# if [[ -f test_coverage.xml ]]; then rm test_coverage.xml; fi && \
+	# if [[ -f .coverage ]]; then rm .coverage; fi && \
+	# if [[ reports ]]; then rm -rf reports; fi

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,13 @@ test: activate-env ## Run the full test suite
 #
 #  * --cov-report xml:test_coverage.xml
 #     Requests an XML-formatted coverage report named test_coverage.xml
-test-coverage: activate-env ## Run the full test suite and generate coverage reports
-	@$(PYTHON) -m pytest -rxXs \
+test-coverage: ## Run the full test suite and generate coverage reports
+	@mkdir reports/coverage --parents && \
+	$(PYTHON) -m pytest -rxXs \
 	--cov=$(APPLICATION_DIR) \
 	--junitxml=test_summary.xml \
-	--cov-report xml:test_coverage.xml
+	--cov-report xml:test_coverage.xml && \
+	coverage xml -o reports/coverage/test_coverage.xml
 
 lint: ## Run linting tools on the application code
 	@$(PYTHON) -m pylint $(APPLICATION_DIR) $(TEST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ install: install-python-deps pre-commit-install ## Install the code and pre-comm
 #  * -rxXs
 #     Provide a detailed summary report.
 #     https://docs.pytest.org/en/6.2.x/usage.html#detailed-summary-report
-test: activate-env ## Run the full test suite
+test: ## Run the full test suite
 	@$(PYTHON) -m pytest -rxXs
 
 # Run the test suite with the following options:

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,11 @@ pre-commit-all: ## Run pre-commit on all files
 	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
 	pre-commit run --all-files
 
+build-dist: ## Build the distribution archives
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	python3 -m pip install wheel && \
+	python3 setup.py sdist bdist_wheel
+
 # TODO - Something like this would be better
 # FILES_TO_CLEAN = (test_summary.xml test_coverage.xml .coverage)
 # for file in ${FILES_TO_CLEAN[@]}; do
@@ -123,4 +128,6 @@ clean: ## Remove any artifacts created by the make targets
 	# if [[ -f test_summary.xml ]]; then rm test_summary.xml; fi && \
 	# if [[ -f test_coverage.xml ]]; then rm test_coverage.xml; fi && \
 	# if [[ -f .coverage ]]; then rm .coverage; fi && \
-	# if [[ reports ]]; then rm -rf reports; fi
+	# if [[ reports ]]; then rm -rf reports; fi && \
+	# if [[ build ]]; then rm -rf build; fi && \
+	# if [[ dist ]]; then rm -rf dist; fi

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,15 @@ TASKS = \
 # .DEFAULT_GOAL is the target that is executed when 'make' is typed
 .DEFAULT_GOAL = help
 
-PYTHON = python3
-
 # Location of application and test code
 APPLICATION_DIR = src/python_package_template/
 TEST_DIR = tests/
 
 # Name of the virtual environment directory
 VIRTUAL_ENV_DIRECTORY = env
+
+# Location of the python executable
+PYTHON = $(VIRTUAL_ENV_DIRECTORY)/bin/python3
 
 # https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
@@ -36,13 +37,13 @@ help:
 	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 create-env: ## Creates the virtual environment directory
-	@$(PYTHON) -m venv $(VIRTUAL_ENV_DIRECTORY)
+	@python3 -m venv $(VIRTUAL_ENV_DIRECTORY)
 
 activate-env: ## Activates the virtual environment
 	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate
 
 install-python-deps: create-env activate-env ## Install the Python dependencies in the virtual environment
-	@$(PYTHON) -m pip install -r requirements.txt -r requirements-dev.txt
+	@python3 -m pip install -r requirements.txt -r requirements-dev.txt
 
 # TODO - This is crying out for Docker...
 install: install-python-deps pre-commit-install ## Install the code and pre-commit
@@ -73,7 +74,7 @@ test-coverage: activate-env ## Run the full test suite and generate coverage rep
 	--junitxml=test_summary.xml \
 	--cov-report xml:test_coverage.xml
 
-lint: activate-env ## Run linting tools on the application code
+lint: ## Run linting tools on the application code
 	@$(PYTHON) -m pylint $(APPLICATION_DIR) $(TEST_DIR)
 
 typecheck: activate-env ## Run static type checking on the application code

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,27 @@ build-dist: ## Build the distribution archives
 	python3 -m pip install wheel && \
 	python3 setup.py sdist bdist_wheel
 
+# Automatically builds the documentation
+#
+# Steps:
+#   - Build dynamic docmentation from the docstrings in the Python
+#     files and modules found in `src/python_package_template`
+#   - Build the static documentation files in `docs/source`
+#
+# Additional args for `sphinx-apidoc`:
+#   * -f:
+#     Force `apidoc` to overwrite files
+#   * -o:
+#     The target directory for the auto-generated docs
+#
+# Additional args for `sphinx-build`
+#   * -b:
+#     The type of documentation to create
+build-docs: ## Build the documentation
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	sphinx-apidoc -f -o docs/source $(APPLICATION_DIR) && \
+	sphinx-build -b html docs/source docs/build
+
 # TODO - Something like this would be better
 # FILES_TO_CLEAN = (test_summary.xml test_coverage.xml .coverage)
 # for file in ${FILES_TO_CLEAN[@]}; do
@@ -130,4 +151,5 @@ clean: ## Remove any artifacts created by the make targets
 	# if [[ -f .coverage ]]; then rm .coverage; fi && \
 	# if [[ reports ]]; then rm -rf reports; fi && \
 	# if [[ build ]]; then rm -rf build; fi && \
-	# if [[ dist ]]; then rm -rf dist; fi
+	# if [[ dist ]]; then rm -rf dist; fi && \
+	# if [[ docs/build ]]; then rm -rf docs/build; fi

--- a/Makefile
+++ b/Makefile
@@ -67,16 +67,16 @@ test: activate-env ## Run the full test suite
 #
 #  * --cov-report xml:test_coverage.xml
 #     Requests an XML-formatted coverage report named test_coverage.xml
-test-coverage: ## Run the full test suite and generate coverage reports
+test-coverage: activate-env ## Run the full test suite and generate coverage reports
 	@$(PYTHON) -m pytest -rxXs \
 	--cov=$(APPLICATION_DIR) \
 	--junitxml=test_summary.xml \
 	--cov-report xml:test_coverage.xml
 
-lint: ## Run linting tools on the application code
+lint: activate-env ## Run linting tools on the application code
 	@$(PYTHON) -m pylint $(APPLICATION_DIR) $(TEST_DIR)
 
-typecheck: ## Run static type checking on the application code
+typecheck: activate-env ## Run static type checking on the application code
 	@$(PYTHON) -m mypy . --strict
 
 format: lint typecheck ## Run linting and type-checking

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,25 @@ typecheck: ## Run static type checking on the application code
 
 format: lint typecheck ## Run linting and type-checking
 
+# Run `bandit` on the repository
+#
+# Additional args:
+# * -r:
+#   Recurse over the directory contents
+# * -x:
+#   Exclude the `./env` directory
+# * -s:
+#   Skip the B101 tests (assert_used)
+security-application: ## Checks for vulnerabilities in application code
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	bandit -r -x ./env -s B101 .
+
+security-dependency: ## Checks for vulnerabilities in dependencies
+	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
+	pip freeze | safety check --stdin
+
+security: security-application security-dependency ## Runs security tools
+
 pre-commit-install: ## Install pre-commit
 	@. ./$(VIRTUAL_ENV_DIRECTORY)/bin/activate && \
 	pre-commit install

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ outline the two main approaches that are prevalent in the Python community.
 This repository provides the basic setup to enable a Setup > Test > Build >
 Document > Deploy workflow.
 
+These operations are supported via a `Makefile`. To view available Make recipes
+you can type `make` in the command prompt and view the documentation.
+
 **Note to Windows users**
 Performance is not guaranteed when running this repository in Windows OS. I may
 look at supporting Windows and/or MAC OS if there is significant demand, however
@@ -67,49 +70,29 @@ for now I have chosen the development path that in my opinion provides the least
 friction, i.e. Windows Subsystem for Linux.
 
 If you want to try running the Python code on this repository then just remember
-that the command to activate the virtual environment in Windows is `source env/Scripts/activate`, not `source env/bin/activate`.
+that the command to activate the virtual environment in Windows is
+`source env/Scripts/activate`, not `source env/bin/activate`.
+
+_This will need to be changed in the `Makefile` aswell_
 
 **Setup**
-```python
-# Create and activate the environment
-python3 -m venv env
-source env/bin/activate
-
-# Install dependencies
-python3 -m pip install -r requirements.txt
-python3 -m pip install -r requirements-dev.txt
+```bash
+make install
 ```
 
 **Test**
-```python
-# Make sure we are in the virtual environment
-source env/bin/activate
-
-# Run all tests using the `pytest` package
-python3 -m pytest
+```bash
+make test
 ```
 
 **Build**
-```python
-# Make sure we are in the virtual environment
-source env/bin/activate
-
-# Build using `setuptools`
-python3 setup.py sdist bdist_wheel
+```bash
+make build-dist
 ```
 
 **Document**
 ```bash
-# Make sure we are in the virtual environment
-source env/bin/activate
-
-# Auto-document the Python package
-#   - Creates the `modules.rst` file in `docs/source`
-sphinx-apidoc -f -o docs/source src/python_package_template
-
-# Build the HTML version of the documentation
-sphinx-build -b html docs/source docs/build
-
+make build-docs
 ```
 
 **Deploy**
@@ -126,21 +109,7 @@ This is by no means prescriptive and is for guidance only.
 ### Setup
 This package uses `venv` to manage dependencies.
 
-Create a virtual environment called `env`
-
-    python3 -m venv env
-
-Activate the environment
-
-    source env/bin/activate
-
-To install the developer dependencies
-
-    python3 -m pip install -r requirements-dev.txt
-
-To install the package dependencies
-
-    python3 -m pip install -r requirements.txt
+See `make create-env` and `make install-python-deps` to view the details.
 
 #### Developer Tools
 This repository uses the following developer tools:
@@ -171,22 +140,25 @@ An example `settings.json` for VS Code is provided below:
 ```
 
 ### Test
-Testing is provided by `pytest` and test files are defined in the `tests` directory.
+Testing is provided by `pytest` and test files are defined in the `tests`
+directory.
 
-To run all tests
+Test discovery supports tests written using Behaviour Driven Development syntax,
+e.g. `def should_pass_this_really_simply_test(arg_1, arg_2, expected)`
 
-    python3 -m pytest
-
-The pytest setup can be heavily customised. See the [pytest docs](https://docs.pytest.org/en/6.2.x/example/index.html) for more information.
+See `make test` and `make test-coverage` to view the details and the
+[pytest docs](https://docs.pytest.org/en/6.2.x/example/index.html) for more
+information.
 
 ### Build
 Packaging is provided by `setuptools`.
 
 To build the source (`.tar.gz`) and distribution (`.whl`) archives
 
-    python3 setup.py sdist bdist_wheel
+    make build-dist
 
-This will create the source (`.tar.gz`) and distribution (`.whl`) archives in the `dist` directory.
+This will create the source (`.tar.gz`) and distribution (`.whl`) archives in
+the `dist` directory.
 
 The package can be installed from these archives using
 ```bash
@@ -198,15 +170,14 @@ python3 -m pip install path_to_the_source_archive.tar.gz
 python3 -m pip install path_to_the_distribution_archive.whl
 ```
 
-The [setuptools documentation](https://packaging.python.org/guides/distributing-packages-using-setuptools/#packaging-your-project) provides details on the differences between the source and distribution archives.
+The [setuptools documentation](https://packaging.python.org/guides/distributing-packages-using-setuptools/#packaging-your-project) provides details on the differences between the source
+and distribution archives.
 
 ### Document
 Documentation is provided by [Sphinx](https://www.sphinx-doc.org/en/master/usage/quickstart.html).
 
 To create the documentation for the Python package automatically we use the
 [sphinx-autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc) extension
-
-    sphinx-apidoc -f -o docs/source src/python_package_template
 
 This allows Sphinx to automatically traverse the contents of the python package
 found at `src/python_package_template` and construct the ReStructuredText `.rst` file
@@ -219,7 +190,7 @@ over the `numpy` style but this is purely a matter of personal taste.
 
 The HTML version of the documentation can be built using
 
-    sphinx-build -b html docs/source docs/build
+    make build-docs
 
 This will create several html files in the `docs/build` directory. To view the
 docs in a web browser simply open the `docs/build/index.html` file.
@@ -243,13 +214,17 @@ The following jobs are defined in the [CircleCI config file](./.circleci/config.
 * `build-dist`: Builds the distribution files and stores the artifacts
 * `build-docs`: Builds the documentation and stores the artifacts
 
-We use the [fan-out/fan-in workflow](https://circleci.com/docs/2.0/workflows/#fan-outfan-in-workflow-example) strategy to maximise concurrency.
+We use the [fan-out/fan-in workflow](https://circleci.com/docs/2.0/workflows/#fan-outfan-in-workflow-example)
+strategy to maximise concurrency.
 
 ![CircleCI workflow diagram for python_package_template repository](https://github.com/ChristopherSzczyglowski/python_package_template/blob/main/docs/source/_static/circleci_workflow_diagram.PNG?raw=true)
 
-The CI jobs `setup-env` and `pre-commit` can be tested locally using the the CircleCI CLI (requires Docker). The other jobs use caching to persist the dependency data between jobs, which is currently unsupported by the CircleCI CLI.
+The CI jobs `setup-env` and `pre-commit` can be tested locally using the the
+CircleCI CLI (requires Docker). The other jobs use caching to persist the
+dependency data between jobs, which is currently unsupported by the CircleCI CLI.
 
-The following resources will assist first time installation for Docker and CircleCI CLI:
+The following resources will assist first time installation for Docker and
+CircleCI CLI:
 
 * Docker
     * [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
@@ -280,8 +255,9 @@ codebase as reported by `bandit`, namely
 and [B603](https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html).
 
 In order for security checks to pass in CI we have explicitly ignored the warnings
-from bandit for the files `versioneer.py` and `src/python_package_template/_version.py` using
-the `# nosec` annotation. We have also updated the `.bandit` config file to ignore assert statements in these files.
+from bandit for the files `versioneer.py` and `src/python_package_template/_version.py`
+using the `# nosec` annotation. We have also updated the `.bandit` config file
+to ignore assert statements in these files.
 
 We favour a targetted approach over a blanket skipping of these tests so that we
 can still expose security vulnerabilities related to these errors downstream


### PR DESCRIPTION
This PR provides a self-documenting `Makefile` for handling all low-level operations such as:
* Building the docs
* Building the distribution files
* Running code checks (linting, type checking, security)
* Running unit tests and calculating test coverage

## New Features
* New `Makefile` added --> Type `make` to view the documentation

## Updates to Database schemas
N/A

## Specific Feedback Requested
N/A `bar` module

## Jira Tickets
N/A

## Linked to
Closes #4 