### PR TITLE
Update pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
     -   id: check-executables-have-shebangs
     -   id: check-docstring-first
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 21.9b0
     hooks:
     -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
     rev: 21.9b0
     hooks:
     -   id: black
+-   repo: https://github.com/asottile/blacken-docs
+    rev: v1.11.0
+    hooks:
+    -   id: blacken-docs
+        additional_dependencies: [black==21.9b0]
+        args: [--line-length=88]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,15 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: check-yaml
+    -   id: check-json
+    -   id: check-toml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+    -   id: mixed-line-ending
+    -   id: check-added-large-files
+    -   id: detect-private-key
+    -   id: check-executables-have-shebangs
+    -   id: check-docstring-first
 -   repo: https://github.com/psf/black
     rev: 21.7b0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,14 @@ repos:
     -   id: blacken-docs
         additional_dependencies: [black==21.9b0]
         args: [--line-length=88]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.9.3
+    hooks:
+    -   id: isort
+        name: isort (python)
+    -   id: isort
+        name: isort (cython)
+        types: [cython]
+    -   id: isort
+        name: isort (pyi)
+        types: [pyi]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,9 +4,10 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import pathlib
+
 # -- Path setup --------------------------------------------------------------
 import sys
-import pathlib
 
 # We need to make sure that Sphinx can import the Python package
 package_path = pathlib.Path(__file__).parents[2] / "src"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ attrs==21.2.0
 Babel==2.9.1
 backports.entry-points-selectable==1.1.0
 bandit==1.7.0
-black==21.7b0
+black==21.9b0
 certifi==2021.5.30
 cfgv==3.3.0
 charset-normalizer==2.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,10 @@ ignore_errors = True
 [mypy-src.python_package_template._version]
 ignore_errors = True
 
+[isort]
+profile = black
+multi_line_output = 3
+
 [pylint.MASTER]
 
 # A comma-separated list of package or module names from where C extensions may

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,8 +1,8 @@
 """Provides the context for running the test suite
 """
 
-import sys
 import os
+import sys
 
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
 

--- a/tests/test_example_module.py
+++ b/tests/test_example_module.py
@@ -4,9 +4,8 @@ from typing import Union
 
 import pytest
 
-from python_package_template import example_module  # pylint: disable=wrong-import-order
-
-from . import context  # pylint: disable=unused-import
+import tests.context  # pylint: disable=unused-import
+from python_package_template import example_module
 
 Number = Union[int, float]
 

--- a/tests/test_example_module.py
+++ b/tests/test_example_module.py
@@ -1,11 +1,12 @@
 """Test suite for the `example_module` module
 """
 from typing import Union
+
 import pytest
 
-from . import context  # pylint: disable=unused-import
-
 from python_package_template import example_module  # pylint: disable=wrong-import-order
+
+from . import context  # pylint: disable=unused-import
 
 Number = Union[int, float]
 


### PR DESCRIPTION
This PR provides an updated `pre-commit-config.yaml` file with additional checks as described in #16 

## New Features
* Updated `pre-commit-config.yaml`
* Additional configuration for `isort` in `setup.cfg`
* Update importing of test context
* Update `black` to `v21.9b0`

## Updates to Database schemas
N/A
## Specific Feedback Requested
N/A
## Jira Tickets
N/A

## Linked to
Closes #16 