### PR TITLE
Ignore formatting commits

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -29,6 +29,10 @@
         "python.testing.pytestArgs": [
             "tests"
         ],
+        "gitlens.advanced.blame.customArguments": [
+            "–ignore-revs-file",
+            ".git-blame-ignore-revs"
+        ],
         "[json]": {
             "editor.defaultFormatter": "vscode.json-language-features"
         }

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Update pre-commit
+3ba97223fd2ab1338548786be20b02537351e9fa

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ See `make create-env` and `make install-python-deps` to view the details.
 #### Developer Tools
 This repository uses the following developer tools:
 
+-   [Docker](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/container-docker-introduction/docker-defined) - Running services in isolated environments
+-   [VS Code Developer Containers](https://code.visualstudio.com/docs/remote/create-dev-container) - Writing and testing code in isolated environments
 * [pre-commit](https://pre-commit.com/): `pre-commit` is provided as a developer dependency. To install pre-commit use `pre-commit install` and then run on all files using `pre-commit run --all-files`
 * [CircleCI](https://circleci.com/): Continuous Integration is provided by CircleCI. The [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) can be used to debug CI jobs locally.
 * [pylint](https://pypi.org/project/pylint/): Linting is provided by `pylint`
@@ -120,7 +122,9 @@ This repository uses the following developer tools:
 * [bandit](https://pypi.org/project/bandit/): Code security is provided by `bandit`
 * [safety](https://pypi.org/project/safety/): `safety` is used to scan dependencies for vulnerabilities.
 
-Example settings are provided in the `.devcontainer.json`.
+Example settings are provided in the [`.devcontainer.json`](.devcontainer.json).
+
+Further details can be found in [DEVELOPMENT.md](docs/DEVELOPMENT.md)
 
 ### Test
 Testing is provided by `pytest` and test files are defined in the `tests`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,40 @@
+# Development Guidance
+Before starting your development you should configure your local git settings.
+
+## Configuring Git
+Following the example in [Rob Allen's blog post](https://akrabat.com/ignoring-revisions-with-git-blame/) provide the `.git-blame-ignore-revs` file to prevent formatting commits from cluttering the file blame history.
+
+Before starting your development you should configure your local git settings to tell git to use this file
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+## Using the Development Container
+
+To set up your local Docker environment you must first [install Docker](https://docs.docker.com/get-docker/).
+
+Verify that Docker is installed and the Docker Daemon is working
+
+```bash
+docker run hello-world
+```
+
+Running VS Code inside a container is part of the Remote Development suite in VS Code. It is a powerful and feature-rich capability that enables tools such as SSH, containers and integration with Windows Subsystem for Linux.
+
+Setting up the containerised development environment is a 2 step process:
+
+1. Install the [Remote Development Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+2. Open the command palette using `Cmd+Shift+P` and run the command `Remote-Containers: Reopen in Container`
+
+You are now inside the container described by the `.devcontainer.json` configuration file.
+
+This environment (container) provides all extensions, environment variables and dependencies required to develop this code - no need for `conda`, `poetry` or `venv`!
+
+You can perform `git` commands using the terminal window in VS Code or in a terminal in the original, non-containerised directory.
+
+Further details can be found in these resources:
+
+-   [Developing inside a container - Installation](https://code.visualstudio.com/docs/remote/containers#_installation)
+-   [Remote development in containers - Tutorial](https://code.visualstudio.com/docs/remote/containers-tutorial)
+-   [Creating a development container](https://code.visualstudio.com/docs/remote/create-dev-container)


### PR DESCRIPTION
This PR provides the `.git-blame-ignore-revs` file for removing formatting commits from the git blame history. 

This feature is inspired by [Rob Allen's blog post](https://akrabat.com/ignoring-revisions-with-git-blame/).

## New Features
* `.git-blame-ignore-revs` is provided to track formatting commits
* Updated documentation in `README.md` and added new file `docs/DEVELOPMENT.md` to provide instructions on how to use the VS Code developer container.

## Linked to
Closes #22 