### PR TITLE
Update black to stable version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,17 +10,16 @@ repos:
     -   id: mixed-line-ending
     -   id: check-added-large-files
     -   id: detect-private-key
-    -   id: check-executables-have-shebangs
     -   id: check-docstring-first
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.11.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==21.9b0]
+        additional_dependencies: [black==22.3.0]
         args: [--line-length=88]
 -   repo: https://github.com/pycqa/isort
     rev: 5.9.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,13 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
--   repo: https://github.com/asottile/blacken-docs
-    rev: v1.11.0
-    hooks:
-    -   id: blacken-docs
-        additional_dependencies: [black==22.3.0]
-        args: [--line-length=88]
+# Disable blacken-docs until this regression bug is fixed: https://github.com/psf/black/issues/2829
+# -   repo: https://github.com/asottile/blacken-docs
+#     rev: v1.11.0
+#     hooks:
+#     -   id: blacken-docs
+#         additional_dependencies: [black==22.3.0]
+#         args: [--line-length=88]
 -   repo: https://github.com/pycqa/isort
     rev: 5.9.3
     hooks:


### PR DESCRIPTION
Also remove shebang pre-commit check as it is just hassle

## New Features
* `black` is now pinned to `v22.3.0`